### PR TITLE
Fix license declaration

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -290,8 +290,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    SBEAT: a classic MacOS 9 app of breeding tool for musical composition developed by T. Unemi in 2001
-    Copyright (C) 2013  unemi
+    one line to give the program's name and an idea of what it does.
+    Copyright (C) yyyy name of author
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/closeBox.c
+++ b/closeBox.c
@@ -1,8 +1,29 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 /*
 struct ControlDefSpec {
-    ControlDefType defType; 
+    ControlDefType defType;
     union {
-          ControlDefUPP defProc; 
+          ControlDefUPP defProc;
       void *classRef;
     } u;
 };

--- a/copy_paste.c
+++ b/copy_paste.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <stdio.h>
 #include	<string.h>
 #include	"decl.h"

--- a/decl.h
+++ b/decl.h
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 //#define  DEBUG
 
 #include	"ftype.h"
@@ -102,7 +123,7 @@ enum {	WIDField =		1,
 #define	IntWindowHeight	(IntegYUnit)
 #define	NintButtons	13
 enum {
-		CntlPalm =	1, CntlSelArrow,	
+		CntlPalm =	1, CntlSelArrow,
 		CntlPlay, CntlStop, CntlPause,
 		CntlNoteUp, CntlNoteDn,
 		CntlShiftL, CntlShiftR,

--- a/dialog.h
+++ b/dialog.h
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #ifndef  RESFILE
 /* Dialog item IDs */
 /* Player Dialog */

--- a/drag.c
+++ b/drag.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <Drag.h>
 #include	"decl.h"
 #define	flavorTypeInd	'SRCI'
@@ -341,7 +362,7 @@ static void drag_ind(DraggedIndividual *s, ItemReference ir, EventRecord *e) {
 	Point	p;
 	DragReference	theDrag = NULL;
 	RgnHandle	dragRegion = NULL, tempRgn = NULL;
-	p.h = p.v = 0; LocalToGlobal(&p); 
+	p.h = p.v = 0; LocalToGlobal(&p);
 	OffsetRect(&s->rect, p.h, p.v);
 	result = NewDrag(&theDrag);
 	if (result) { msg = "\pNewDrag"; goto error; }

--- a/draw.c
+++ b/draw.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  "decl.h"
 #include	"pcolor.h"
 extern	WindowPtr	TopWindow, PlayWindow;
@@ -70,7 +91,7 @@ static void draw_bm(short code) {
 	GetGWorld(&dport, &gdh);
 	GetPen(&pt);
 	dr = bMap[code].bounds;
-	OffsetRect(&dr, pt.h - bMapOffset[code].h, pt.v - bMapOffset[code].v); 
+	OffsetRect(&dr, pt.h - bMapOffset[code].h, pt.v - bMapOffset[code].v);
 	CopyMask(&bMap[code], &bMap[code],
 		GetPortBitMapForCopyBits(dport),
 		&bMap[code].bounds, &bMap[code].bounds, &dr);

--- a/evolv.c
+++ b/evolv.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <string.h>
 #include	"decl.h"
 #define	MutationRate	0.05

--- a/field.c
+++ b/field.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <stdio.h>
 #include	<string.h>
 #include	"decl.h"
@@ -62,7 +83,7 @@ void check_win_menu_item(WindowPtr window) {
 	MenuHandle	mh = GetMenuHandle(mWindow);
 	for (i = 0; i < WindowCount; i ++)
 		CheckMenuItem(mh, i + iWindowList, (WindowsInMenu[i] == window));
-}	
+}
 static void set_button_icon(ControlHandle control, Boolean flag,
 	short iconOn, short iconOff, short refOn, short refOff) {
 	ControlButtonContentInfo	cinfo;

--- a/file.c
+++ b/file.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <Navigation.h>
 #include	<StandardFile.h>
 #include	<stdio.h>
@@ -170,7 +191,7 @@ static void smf_navi_customize(NavCBRecPtr callBackParms) {
 				callBackParms->customRect.bottom = neededHeight;
 	}
 	LastTryWidth = callBackParms->customRect.right;
-	LastTryHeight = callBackParms->customRect.bottom;	
+	LastTryHeight = callBackParms->customRect.bottom;
 }
 static void get_real_name_of_user(unsigned char *name) {
 	OSErr	err;
@@ -239,7 +260,7 @@ static void smf_navi_finish(DialogPtr dlg, NavCallBackUserData cl) {
 	GetDialogItemAsControl(dlg, VolumeAdjustCBoxID, &control);
 	smfInfo->adjust = GetControlValue(control);
 }
-static pascal void myEventProc(const NavEventCallbackMessage callBackSelector, 
+static pascal void myEventProc(const NavEventCallbackMessage callBackSelector,
 	NavCBRecPtr callBackParms, NavCallBackUserData cl) {
 	EventRecord	*e = callBackParms->eventData.eventDataParms.event;
 	switch (callBackSelector) {

--- a/ftype.h
+++ b/ftype.h
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #ifdef  PLST
 #define	CreatorCode			"SBST"
 #define	FileTypeField		"sFl3"

--- a/gedit.c
+++ b/gedit.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <stdio.h>
 #include	<string.h>
 #include	"decl.h"

--- a/integrator.c
+++ b/integrator.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <stdio.h>
 #include	<string.h>
 #include	"decl.h"
@@ -648,7 +669,7 @@ static void shrink_integ(SBIntegrator *si) {
 		if (ItgOnP(scorep, k)) onMask |= m;
 		if (ItgSelectedP(scorep, k))
 			{ nselb ++; scorep[k].flag &= ~ItgSelectedFlag; }
-	} 
+	}
 	HUnlock((Handle)si->scoreHandle);
 	enque_integ_history(HistIShrink, si, onMask, 0);
 	SetHandleSize((Handle)si->scoreHandle,
@@ -878,7 +899,7 @@ static short find_section(SBIntegrator *si, Point where, short *part) {
 	row = (y = where.v + si->scroll - intWinTopSpace) / si->barHeight;
 	if ((y -= row * si->barHeight) > SubWinPHeight / si->displayScale) return -1;
 	if (part) *part = y * si->displayScale / PartHeight;
-	return row * si->nSectionsW + ((where.h - WinLeftSpace) / si->barWidth);	
+	return row * si->nSectionsW + ((where.h - WinLeftSpace) / si->barWidth);
 }
 static void click_scroll_bar(SBIntegrator *si, Point where, short modifiers) {
 	static	DragGrayRgnUPP		thumbUPP = NULL;

--- a/main.c
+++ b/main.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <stdio.h>
 #include	<string.h>
 #include	<InternetConfig.h>
@@ -151,7 +172,7 @@ short save_change_alert(WindowPtr win, short idx) {
 	if (!ap.filterProc) {
 		ap.filterProc = NewModalFilterUPP(&my_sc_alert_filter);
 		GetIndString(msg, kBaseResID+2, idxLabelSave);
-		ap.otherText = p = msg + msg[0] + 1;; 
+		ap.otherText = p = msg + msg[0] + 1;;
 		GetIndString(p, kBaseResID+2, idxLabelDont);
 	}
 	if (IsWindowCollapsed(win)) {
@@ -483,7 +504,7 @@ static void draw_infowindow(void) {
 		ReleaseResource((Handle)p);
 		SetPort(old);
 	}
-}	
+}
 void DoUpdate(EventRecord *e) {
 	WindowPtr	win = (WindowPtr)e->message;
 	RgnHandle	visRgn = NewRgn();

--- a/partoption.c
+++ b/partoption.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <stdio.h>
 #include	<string.h>
 #include	"decl.h"
@@ -131,8 +152,8 @@ enum {	// index ID of Help tags
 #define	poptionRDsclsr	0xc00
 #define	poptionKindMask	0xf00
 #define	poptionPartMask	0x0ff
-#define	getColumnID(v)	((((v)>>12)&0x0f)-1)	
-#define	columnID(id)	(((id)+1)<<12) 
+#define	getColumnID(v)	((((v)>>12)&0x0f)-1)
+#define	columnID(id)	(((id)+1)<<12)
 extern	RGBColor	partColor[];
 static	char	*partIDNames[] = {
 	"S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8", "S9", "S10", "S11", "S12", "S13",
@@ -169,7 +190,7 @@ static void set_text(ControlRef txt, unsigned char *pstr) {
 	SetControlData(txt, kControlEntireControl,
 		kControlStaticTextTextTag, pstr[0], pstr + 1);
 	DrawOneControl(txt);
-}	
+}
 static void set_digits(ControlRef txt, long value) {
 	unsigned char	pstr[16];
 	NumToString(value, pstr);
@@ -288,7 +309,7 @@ static void draw_protection_indicator0(Rect *bound, short chromosome) {
 	rect.top = bound->top + chromosome * poptionButtonSize / 3;
 	rect.bottom = bound->top + (chromosome + 1) * poptionButtonSize / 3 - 2;
 	PaintRect(&rect);
-}	
+}
 static void draw_protection_indicator(short part, short chromosome) {
 	Rect	bound;
 	if (partClosed[(part < DsPercPart)? part : part + 1]) return;

--- a/pcolor.h
+++ b/pcolor.h
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 // Definition of Color (RGB) for part names
 // Part#1 ... Soprano1 = red
 #define Part1R 0xdddd

--- a/player.c
+++ b/player.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  "decl.h"
 #include	"dialog.h"
 #include	"vers.h"

--- a/score.c
+++ b/score.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 /*
   theScore[i] contains the basic score (0 ... 15)
 	ind->score[GuitarPart][i].note = 0 ... 15
@@ -91,7 +112,7 @@ void develop_score(Individual *ind, BarInfo *bi) {
 	for (p = DsPercPart; p < NTotalParts; p ++)
 	for (i = len = 0; i < NShortBeats; i ++)
 	switch (ind->score[p][i].note) {
-		case NoteRest: case NoteRemain: 
+		case NoteRest: case NoteRemain:
 		if (len > 0) {
 			len ++;
 			if (len > 4) { ind->score[p][i].note = NoteRest; len = 0; }

--- a/score.h
+++ b/score.h
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #define  RemainGene	0x80
 #define	RemainP(x)	((x & 0x80) == 0x80)
 #define	PauseP(x)	((x & 0xe0) == 0x60)

--- a/seq.c
+++ b/seq.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <stdio.h>
 #include	<string.h>
 #include	<QuickTimeMusic.h>
@@ -175,7 +196,7 @@ Boolean cymbalP(short part, short note, BarInfo *pi) {
 	unsigned char	*ls = timbreList[pi->drumsInst[part - DsPercPart] & 0xff];
 	note = ls[((note & 0x7f) % ls[0]) + 1] - FirstDsPitch;
 	return ((CymbalFlags[note / 8] & (0x80 >> (note % 8))) != 0);
-} 
+}
 short cntlID[] = {
 /*	kControllerModulationWheel, */
 /*	kControllerBreath, */
@@ -306,7 +327,7 @@ static void stuff_note_event(short part, short pitch, short vel, long duration) 
 	if (32 <= pitch && pitch <= 95 && duration < 0x800) {
 		qtma_StuffNoteEvent(Tune->tune[tuneIndex], part+1, pitch, vel, duration);
 		tuneIndex ++;
-	} else { 
+	} else {
 		qtma_StuffXNoteEvent(Tune->tune[tuneIndex], Tune->tune[tuneIndex+1],
 			part+1, pitch, vel, duration);
 		tuneIndex += 2;
@@ -859,7 +880,7 @@ static void monitorx(TuneStatus *st) {
 	line[0] = strlen((char *)line+1); MoveTo(10,160); DrawString(line);
 	sprintf((char *)line+1, "NextWin=0x%X, NextID=%d", NextWin, NextID);
 	line[0] = strlen((char *)line+1); MoveTo(10,180); DrawString(line);
-	
+
 	SetPort(oldport);
 }
 #endif

--- a/smf.c
+++ b/smf.c
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 #include  <stdio.h>
 #include	<string.h>
 #include	<QuickTimeMusic.h>
@@ -324,7 +345,7 @@ void write_smf(WindowPtr win, short ref, smfOptionalInfo *smfInfo) {
 		BlockMove(dateStr+1, MidiBuffer+k+seqName[0]+1, dateStr[0]);
 		MidiBuffer[k] += dateStr[0];
 	}
-	k += MidiBuffer[k] + 1; 
+	k += MidiBuffer[k] + 1;
 	BlockMove(timeMark, MidiBuffer+k, 8); k += 8;		/* Time signature */
 	MidiBuffer[k ++] = '\0'; MidiBuffer[k ++] = 0xff;	/* Key signature */
 	MidiBuffer[k ++] = 0x59; MidiBuffer[k ++] = 0x02;

--- a/timbre.h
+++ b/timbre.h
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 enum {
   diBassDrums, diHiHatPedal, diDsStick, diTomTom, diSnare, diHiHat,
 	diRideCymbal, diCrashCymbal, diConga, diBongo, diTimbale, diSurdo, diAgogo,

--- a/vers.h
+++ b/vers.h
@@ -1,3 +1,24 @@
+/**
+  SBEAT: A classic MacOS 9 app of breeding tool for musical composition
+  developed by T. Unemi in 2001
+  Copyright (C) 2013  unemi
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+
 /* This "include file" is for the English version. */
 #define  MajorRevision	3
 #define	MinorRevision	2


### PR DESCRIPTION
Hi, thanks for SBEAT!

I'm about to add node.js package metadata so your repo can be downloaded using npm, the Node.js Package Manager. However, first I have to clarify the license. I wondered why none of your files had the GPL header, and found you instead modified the tutorial in the license file. Courts might doubt whether that's meant as a license declaration, so I prepared traditional GPL v2+ file headers. I hope this is what you had intended all the time.

My text editor also removed some end-of-line whitespace, I guess you won't miss it.